### PR TITLE
Change scope in register function for $app

### DIFF
--- a/src/Krucas/Notification/NotificationServiceProvider.php
+++ b/src/Krucas/Notification/NotificationServiceProvider.php
@@ -32,7 +32,7 @@ class NotificationServiceProvider extends ServiceProvider {
 
 		$this->app['notification'] = $this->app->share(function($app)
         {
-            return new Notification($this->app['config'], $this->app['session']);
+            return new Notification($app['config'], $app['session']);
         });
 	}
 


### PR DESCRIPTION
When running unit tests, the register fails since $this is not in object context.

This change simply uses the $app variable that is passed, same result occurs, but unit testing is allowed to process
