### PR TITLE
Fixed breaking issue with non-file-based Session drivers

### DIFF
--- a/src/Krucas/Notification/NotificationServiceProvider.php
+++ b/src/Krucas/Notification/NotificationServiceProvider.php
@@ -47,7 +47,7 @@ class NotificationServiceProvider extends ServiceProvider
         });
 
         $this->app->bind('Krucas\Notification\Subscriber', function ($app) {
-            return new Subscriber($app['session.store'], $app['config']);
+            return new Subscriber($app['session'], $app['config']);
         });
 
         $this->app['events']->subscribe('Krucas\Notification\Subscriber');

--- a/src/Krucas/Notification/Subscriber.php
+++ b/src/Krucas/Notification/Subscriber.php
@@ -1,7 +1,7 @@
 <?php namespace Krucas\Notification;
 
 use Illuminate\Config\Repository;
-use Illuminate\Session\Store;
+use Illuminate\Session\SessionManager;
 
 class Subscriber
 {
@@ -15,7 +15,7 @@ class Subscriber
     /**
      * Session instance for flashing messages.
      *
-     * @var \Illuminate\Session\Store
+     * @var \Illuminate\Session\SessionManager
      */
     protected $session;
 
@@ -29,10 +29,10 @@ class Subscriber
     /**
      * Create new subscriber.
      *
-     * @param \Illuminate\Session\Store $session
+     * @param \Illuminate\Session\SessionManager $session
      * @param \Illuminate\Config\Repository $config
      */
-    public function __construct(Store $session, Repository $config)
+    public function __construct(SessionManager $session, Repository $config)
     {
         $this->session = $session;
         $this->config = $config;
@@ -41,7 +41,7 @@ class Subscriber
     /**
      * Get session instance.
      *
-     * @return \Illuminate\Session\Store
+     * @return \Illuminate\Session\SessionManager
      */
     public function getSession()
     {

--- a/tests/SubscriberTest.php
+++ b/tests/SubscriberTest.php
@@ -14,7 +14,7 @@ class SubscriberTest extends PHPUnit_Framework_TestCase
     public function testIsConstructed()
     {
         $subscriber = $this->getSubscriber();
-        $this->assertInstanceOf('Illuminate\Session\Store', $subscriber->getSession());
+        $this->assertInstanceOf('Illuminate\Session\SessionManager', $subscriber->getSession());
         $this->assertInstanceOf('Illuminate\Config\Repository', $subscriber->getConfig());
     }
 
@@ -70,7 +70,7 @@ class SubscriberTest extends PHPUnit_Framework_TestCase
 
     public function testOnFlash()
     {
-        $session = $this->getSessionStore();
+        $session = $this->getSessionManager();
         $config = $this->getConfigRepository();
         $subscriber = m::mock('SubscriberMock[flashContainerNames,generateMessageKey,getSession,getConfig]');
 
@@ -114,13 +114,13 @@ class SubscriberTest extends PHPUnit_Framework_TestCase
 
     protected function getSubscriber()
     {
-        $subscriber = new SubscriberMock($this->getSessionStore(), $this->getConfigRepository());
+        $subscriber = new SubscriberMock($this->getSessionManager(), $this->getConfigRepository());
         return $subscriber;
     }
 
-    protected function getSessionStore()
+    protected function getSessionManager()
     {
-        return m::mock('Illuminate\Session\Store');
+        return m::mock('Illuminate\Session\SessionManager');
     }
 
     protected function getConfigRepository()


### PR DESCRIPTION
In Laravel, Session has a _SessionManager_. This class has a `__call()` method to send all it's function calls through its driver: _Store_. 

In the current code, `$app['session.store']` is being used in the service provider. When we switched the session driver to memcached, `$app['session.store']` wasn't loading all of the services it needed to use the session. We got an Exception.

When we switched this to `$app['session']` and switched the type hint in _Subscriber.php_, everything worked fine. This is because `$app['session']` uses the _SessionManager_ instead of it's driver: _Store_.

We haven't tested this in Laravel 4.0 but it does resolve this issue in 4.1.
