### PR TITLE
Fix for Issue #29

### DIFF
--- a/src/Krucas/Notification/Collection.php
+++ b/src/Krucas/Notification/Collection.php
@@ -46,10 +46,10 @@ class Collection extends BaseCollection implements RenderableInterface
     /**
      * Determines if given message is already in collection.
      *
-     * @param Message $message
+     * @param $message
      * @return bool
      */
-    public function contains(Message $message)
+    public function contains($message)
     {
         return in_array($message, $this->items);
     }


### PR DESCRIPTION
Fixes #29
This removes the type hint for `Collection::contains` to match Laravel 4.2's [current signature for this method](https://github.com/illuminate/support/blob/8d389be3efdc62cb56d35997930299e1a7a7245a/Collection.php#L81) with no type hint. Unit tests still pass. This is the only method in the `Collection` class that overrides anything from the Illuminate Collection.
