### PR TITLE
Make Notification\Collection::contains() compatible with Illuminate\Supp...

### DIFF
--- a/src/Krucas/Notification/Collection.php
+++ b/src/Krucas/Notification/Collection.php
@@ -49,9 +49,9 @@ class Collection extends BaseCollection implements RenderableInterface
      * @param Message $message
      * @return bool
      */
-    public function contains(Message $message)
+    public function contains($value)
     {
-        return in_array($message, $this->items);
+        return in_array($value, $this->items);
     }
 
     /**


### PR DESCRIPTION
Getting `Declaration of Krucas\Notification\Collection::contains() should be compatible with Illuminate\Support\Collection::contains($value)` error with `laravel/framework 4.2.7`. I believe this fixes the issue.
