### PR TITLE
remove early Blade::Compiler dependency

### DIFF
--- a/src/Krucas/Notification/NotificationServiceProvider.php
+++ b/src/Krucas/Notification/NotificationServiceProvider.php
@@ -28,12 +28,14 @@ class NotificationServiceProvider extends ServiceProvider
 
         $dispatcher->subscribe('Krucas\Notification\Subscriber');
 
-        Blade::directive('notification', function ($container = null) {
-            if (strcasecmp('()', $container) === 0) {
-                $container = null;
-            }
+        $this->app->afterResolving('blade.compiler', function (BladeCompiler $bladeCompiler) {
+            $bladeCompiler->directive('notification', function ($container = null) {
+                if (strcasecmp('()', $container) === 0) {
+                    $container = null;
+                }
 
-            return "<?php echo app('notification')->container({$container})->show(); ?>";
+                return "<?php echo app('notification')->container({$container})->show(); ?>";
+            });
         });
     }
 


### PR DESCRIPTION
and is now really loaded when used. 

If package used in a project an dependency is introduced by Blade::Compiler so that Blade is resolved early and difficult to mock or stub.  In this patch the Blade:: Compiler is now only resolved on using...