### PR TITLE
Escape message for better flexibility

### DIFF
--- a/src/Krucas/Notification/Message.php
+++ b/src/Krucas/Notification/Message.php
@@ -254,8 +254,9 @@ class Message implements Renderable, Jsonable, Arrayable
      */
     public function render()
     {
-        return is_null($this->getMessage())
-            ? '' : str_replace([':message', ':type'], [$this->getMessage(), $this->getType()], $this->getFormat());
+        $message = htmlspecialchars($this->getMessage(), ENT_QUOTES, null, false);
+        return is_null($message)
+            ? '' : str_replace([':message', ':type'], [$message, $this->getType()], $this->getFormat());
     }
 
     /**

--- a/src/Krucas/Notification/Message.php
+++ b/src/Krucas/Notification/Message.php
@@ -254,9 +254,11 @@ class Message implements Renderable, Jsonable, Arrayable
      */
     public function render()
     {
+        if (is_null($this->getMessage())) {
+            return '';
+        }
         $message = htmlspecialchars($this->getMessage(), ENT_QUOTES, null, false);
-        return is_null($message)
-            ? '' : str_replace([':message', ':type'], [$message, $this->getType()], $this->getFormat());
+        return str_replace([':message', ':type'], [$message, $this->getType()], $this->getFormat());
     }
 
     /**


### PR DESCRIPTION
For the scenario where the message format is `<script>alert(':message');</script>` the notification will break if there is a single quote inside the `:message`.

The call to `htmspecialchars` ensures `double_encoding` is disabled so it will still work if message is `"Hello &quot;World&quot;"`.