### PR TITLE
Fixes Laravel 5.4 wildcard event listening signature change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - hhvm

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 php:
   - 5.6
   - 7.0
+  - 7.1
   - hhvm
 
 before_script:

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "illuminate/session": "^5.4"
     },
     "require-dev": {
-        "mockery/mockery": "0.7.*"
+        "mockery/mockery": "~0.9",
+        "phpunit/phpunit": "~5.7"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     "license": "MIT",
     "require": {
         "php" : "^5.5|^7.0",
-        "illuminate/support": "^5.1",
-        "illuminate/session": "^5.1"
+        "illuminate/support": "^5.4",
+        "illuminate/session": "^5.4"
     },
     "require-dev": {
         "mockery/mockery": "0.7.*"

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php" : "^5.5|^7.0",
+        "php" : "^5.6|^7.0",
         "illuminate/support": "^5.4",
         "illuminate/session": "^5.4"
     },

--- a/src/Krucas/Notification/Subscriber.php
+++ b/src/Krucas/Notification/Subscriber.php
@@ -61,15 +61,7 @@ class Subscriber
      */
     public function onFlash($eventName, array $data)
     {
-        // Data array should have 3 elements with sequential keys: Notification, NotificationsBag and Message
-        if ( ! array_key_exists(0, $data) || ! array_key_exists(1, $data) || ! array_key_exists(2, $data)) {
-            throw new \InvalidArgumentException(sprintf('%s expects 3 elements in data array, %s given.', __METHOD__, count($data)));
-        }
-        if ( ! $data[0] instanceof Notification || ! $data[1] instanceof NotificationsBag || ! $data[2] instanceof Message) {
-            throw new \InvalidArgumentException(sprintf('%s expects a data array containing [%s], actually given [%s]', __METHOD__, implode(', ', [Notification::class, NotificationsBag::class, Message::class]), implode(', ', array_map(function ($element) {
-                return is_object($element) ? get_class($element) : '{' . gettype($element) . '}';
-            }, $data))));
-        }
+        $this->validateEventData($data);
 
         list($notification, $notificationBag, $message) = $data;
 
@@ -89,5 +81,39 @@ class Subscriber
     public function subscribe($events)
     {
         $events->listen('notification.flash: *', 'Krucas\Notification\Subscriber@onFlash');
+    }
+
+    /**
+     * Validates that the correct event data has been passed to self::onFlash()
+     *
+     * Data array should have 3 elements with sequential keys: Notification, NotificationsBag and Message
+     *
+     * @param  array  $data
+     * @throws InvalidArgumentException  If the event data is invalid.
+     */
+    private function validateEventData(array $data)
+    {
+        if ( ! array_key_exists(0, $data) || ! array_key_exists(1, $data) || ! array_key_exists(2, $data)) {
+            throw new \InvalidArgumentException(sprintf(
+                '%s expects 3 elements in data array, %s given.',
+                sprintf('%s::onFlash', __CLASS__),
+                count($data)
+            ));
+        }
+
+        if ( ! $data[0] instanceof Notification || ! $data[1] instanceof NotificationsBag || ! $data[2] instanceof Message) {
+            $expected = [Notification::class, NotificationsBag::class, Message::class];
+
+            $actual = array_map(function ($element) {
+                return is_object($element) ? get_class($element) : '{' . gettype($element) . '}';
+            }, $data);
+
+            throw new \InvalidArgumentException(sprintf(
+                '%s expects a data array containing [%s], actually given [%s]',
+                sprintf('%s::onFlash', __CLASS__),
+                implode(', ', $expected),
+                implode(', ', $actual)
+            ));
+        }
     }
 }

--- a/src/Krucas/Notification/Subscriber.php
+++ b/src/Krucas/Notification/Subscriber.php
@@ -54,13 +54,25 @@ class Subscriber
     /**
      * Execute this event to flash messages.
      *
-     * @param Notification $notification
-     * @param NotificationsBag $notificationBag
-     * @param Message $message
+     * @param string $eventName
+     * @param array  $data       Event payload. Should be an array containing 3 elements:
+     *                           [ Notification, NotificationsBag, Message ]
      * @return bool
      */
-    public function onFlash(Notification $notification, NotificationsBag $notificationBag, Message $message)
+    public function onFlash($eventName, array $data)
     {
+        // Data array should have 3 elements with sequential keys: Notification, NotificationsBag and Message
+        if ( ! array_key_exists(0, $data) || ! array_key_exists(1, $data) || ! array_key_exists(2, $data)) {
+            throw new \InvalidArgumentException(sprintf('%s expects 3 elements in data array, %s given.', __METHOD__, count($data)));
+        }
+        if ( ! $data[0] instanceof Notification || ! $data[1] instanceof NotificationsBag || ! $data[2] instanceof Message) {
+            throw new \InvalidArgumentException(sprintf('%s expects a data array containing [%s], actually given [%s]', __METHOD__, implode(', ', [Notification::class, NotificationsBag::class, Message::class]), implode(', ', array_map(function ($element) {
+                return is_object($element) ? get_class($element) : '{' . gettype($element) . '}';
+            }, $data))));
+        }
+
+        list($notification, $notificationBag, $message) = $data;
+
         $key = implode('.', [$this->key, $notificationBag->getName()]);
 
         $this->session->push($key, $message);

--- a/tests/SubscriberTest.php
+++ b/tests/SubscriberTest.php
@@ -41,10 +41,28 @@ class SubscriberTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($subscriber->onFlash('notification.flash: default', [$notification, $notificationsBag, $message]));
     }
 
+    public function testOnFlashValidation()
+    {
+        $subscriber = $this->getSubscriber();
+
+        try {
+            $subscriber->onFlash('notification.flash: default', [new \stdClass]);
+            $this->fail('Failed to throw expected InvalidArgumentException when passing incorrect number of event data array elements to Krucas\Notification\Subscriber::onFlash');
+        } catch (\InvalidArgumentException $e) {
+            $this->assertEquals('Krucas\Notification\Subscriber::onFlash expects 3 elements in data array, 1 given.', $e->getMessage());
+        }
+
+        try {
+            $subscriber->onFlash('notification.flash: default', [new \stdClass, new \stdClass, new \stdClass]);
+            $this->fail('Failed to throw expected InvalidArgumentException when passing incorrect type of event data array elements to Krucas\Notification\Subscriber::onFlash');
+        } catch (\InvalidArgumentException $e) {
+            $this->assertEquals('Krucas\Notification\Subscriber::onFlash expects a data array containing [Krucas\Notification\Notification, Krucas\Notification\NotificationsBag, Krucas\Notification\Message], actually given [stdClass, stdClass, stdClass]', $e->getMessage());
+        }
+    }
+
     protected function getSubscriber()
     {
-        $subscriber = new \Krucas\Notification\Subscriber($this->getSessionStore(), 'notifications');
-        return $subscriber;
+        return new \Krucas\Notification\Subscriber($this->getSessionStore(), 'notifications');
     }
 
     protected function getSessionStore()

--- a/tests/SubscriberTest.php
+++ b/tests/SubscriberTest.php
@@ -32,10 +32,13 @@ class SubscriberTest extends PHPUnit_Framework_TestCase
         $notificationsBag = $this->getNotificationsBag();
         $message = $this->getMessage();
 
-        $notificationsBag->shouldReceive('getName')->once()->andReturn('test');
-        $subscriber->getSession()->shouldReceive('push')->once()->with('notifications.test', $message);
+        $notificationsBag->shouldReceive('getName')->once()->andReturn('my_test_bag');
+        $subscriber->getSession()->shouldReceive('push')->once()->with('notifications.my_test_bag', $message);
 
-        $this->assertTrue($subscriber->onFlash($notification, $notificationsBag, $message));
+        // As of Laravel 5.4 wildcard event subscribers now receive the event
+        // name as their first argument and the array of event data as their
+        // second argument
+        $this->assertTrue($subscriber->onFlash('notification.flash: default', [$notification, $notificationsBag, $message]));
     }
 
     protected function getSubscriber()


### PR DESCRIPTION
Laravel 5.4 has changed the way wildcard event subscribers work. They now receive the event name as their first argument and the array of event data as their second argument, meaning the method signature of `Krucas\Notification\Subscriber::onFlash` no longer works. This same issue has also been noted in #81.

This pull request fixes this issue.

I've created [a repository](https://github.com/surupartners/notification-issue81-test) and [written instructions](https://github.com/surupartners/notification-issue81-test/blob/master/readme.md) to help you replicate the bug and verify that this PR fixes the issue.