### PR TITLE
Allow HTML while still escaping quotes for JS code

### DIFF
--- a/src/Krucas/Notification/Message.php
+++ b/src/Krucas/Notification/Message.php
@@ -257,7 +257,7 @@ class Message implements Renderable, Jsonable, Arrayable
         if (is_null($this->getMessage())) {
             return '';
         }
-        $message = htmlspecialchars($this->getMessage(), ENT_QUOTES, null, false);
+        $message = stripslashes(addslashes($this->getMessage()));
         return str_replace([':message', ':type'], [$message, $this->getType()], $this->getFormat());
     }
 


### PR DESCRIPTION
There was a previous PR which allowed for the message to be included in `<script>` and other places by adding slashes. The correct method to use here is not `htmlspecialchars` but `addslashes` which also allows HTML to continue to work as the former converts `<` and `>` to HTML entities.