### PR TITLE
Improve message filtering

### DIFF
--- a/src/Krucas/Notification/Message.php
+++ b/src/Krucas/Notification/Message.php
@@ -257,7 +257,7 @@ class Message implements Renderable, Jsonable, Arrayable
         if (is_null($this->getMessage())) {
             return '';
         }
-        $message = htmlspecialchars($this->getMessage(), ENT_QUOTES, null, false);
+        $message = htmlspecialchars_decode(htmlspecialchars($this->getMessage(), ENT_QUOTES, null, false), ENT_NOQUOTES);
         return str_replace([':message', ':type'], [$message, $this->getType()], $this->getFormat());
     }
 


### PR DESCRIPTION
A previous PR https://github.com/edvinaskrucas/notification/pull/86 escaped quotes. This gave the flexibility of messages to be included in `<script>` tag, however, `htmlspecialchars` also encoded `<` and `>` which means that `<a>, <b>` etc tags in messages would no longer work. The fix is to encode then decode everything except quotes. The result is that only quotes will be encoded. This seems like the sanest approach http://stackoverflow.com/a/1364961/50475